### PR TITLE
fix issue with incorect handling missing paths

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -58,8 +58,8 @@ func New(s *spec.Swagger, reporter Reporter, opts ...ProxyOpt) (*Proxy, error) {
 	}
 	proxy.reverseProxy = httputil.NewSingleHostReverseProxy(rpURL)
 
-	proxy.router.NotFoundHandler = http.HandlerFunc(proxy.notFound)
 	proxy.registerPaths()
+	proxy.router.NotFoundHandler = http.HandlerFunc(proxy.notFound)
 
 	return proxy, nil
 }


### PR DESCRIPTION
Due to creation of new router in func registerPaths, we losing NotFoundHandler. And proxy incorrectly disallow such API with 404. This pull request intended to fix that.